### PR TITLE
RTI-40: Update Checkmarx workflow with scheduled scan support

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -27,6 +27,7 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
+                preset: "ASA Premium"
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast
@@ -64,6 +65,7 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
+                preset: "ASA Premium"
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -12,6 +12,9 @@ jobs:
   checkmarx-scan:
         name: Checkmarx SAST Scan
         runs-on: ubuntu-latest
+        concurrency:
+            group: checkmarx-${{ github.head_ref || github.ref }}
+            cancel-in-progress: true
         timeout-minutes: 90
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
 
@@ -51,6 +54,9 @@ jobs:
   checkmarx-scheduled-scan:
         name: Checkmarx scheduled SAST Scan
         runs-on: ubuntu-latest
+        concurrency:
+            group: checkmarx-scheduled-scan
+            cancel-in-progress: true
         timeout-minutes: 360
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -4,17 +4,20 @@ on:
     branches:
     - main
     - master
+  schedule:
+    # Run on the 28th of every month at 2 AM UTC (safe for all months)
+    - cron: '0 2 28 * *'
+  workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
   checkmarx-scan:
-       name: Checkmarx SAST Scan
-       runs-on: ubuntu-latest
-       timeout-minutes: 300
-
-       steps:
+        name: Checkmarx SAST Scan
+        runs-on: ubuntu-latest
+        timeout-minutes: 90
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'  # Skip this job on scheduled runs
+        steps:
             - name: Checkout Code
               uses: actions/checkout@v4
-
             - name: Run Checkmarx SAST Scan
               uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
               with:
@@ -24,25 +27,56 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
-
+                # Project configuration
+                project: Replicon-${{ github.event.repository.name }}
+                scanners: sast
+                # bug_tracker: GitHub
+                incremental: true
+                break_build: false
+                # Scan parameters and thresholds
+                params: >-
+                  --namespace=${{ github.repository_owner}}
+                  --checkmarx.settings-override=true
+                  --repo-name=${{ github.event.repository.name}}
+                  --branch=${{ github.ref_name || github.head_ref}}
+                  --cx-flow.filterSeverity
+                  --cx-flow.thresholds.high=1
+                  --cx-flow.thresholds.medium=1
+                  --cx-flow.scan-resubmit=true
+                  ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
+                  
+  checkmarx-scheduled-scan:
+        name: Checkmarx scheduled SAST Scan
+        runs-on: ubuntu-latest
+        timeout-minutes: 360
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.repository.default_branch }}
+            - name: Run Checkmarx SAST Scan
+              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+              with:
+                # Connection parameters
+                checkmarx_url: https://cmxext.deltek.com
+                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+                team: "/CxServer/Security/Deltek/Replicon"
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast
                 # bug_tracker: GitHub
                 incremental: false
                 break_build: false
-
                 # Scan parameters and thresholds
                 params: >-
-                  --logging.level.com.checkmarx=DEBUG
                   --namespace=${{ github.repository_owner}}
                   --checkmarx.settings-override=true
                   --repo-name=${{ github.event.repository.name}}
-                  --branch=${{ github.ref_name || github.head_ref}}
-                  --checkmarx.scan-timeout=1440
+                  --branch=${{ github.event.repository.default_branch }}
                   --cx-flow.filterSeverity
                   --cx-flow.thresholds.high=1
                   --cx-flow.thresholds.medium=1
                   --cx-flow.scan-resubmit=true
-                  ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
-  

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -5,92 +5,18 @@ on:
     - main
     - master
   schedule:
-    - cron: '0 13 * * 6'
+    - cron: '0 13 * * 5'
   workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
-  checkmarx-scan:
-        name: Checkmarx SAST Scan
-        runs-on: ubuntu-latest
-        concurrency:
-            group: checkmarx-${{ github.head_ref || github.ref }}
-            cancel-in-progress: true
-        timeout-minutes: 90
-        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+  call-reusable-checkmarx:
+    name: Call Reusable Checkmarx Workflow
+    uses: Replicon/time-intelligence-web/.github/workflows/reusable-checkmarx.yml@main
+    with:
+      timeout_minutes: 90
+      scheduled_timeout_minutes: 360
+    secrets:
+      checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+      checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+      checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
 
-        steps:
-          - name: Checkout Code
-            uses: actions/checkout@v4
-
-          - name: Run Checkmarx SAST Scan
-            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-            with:
-              # Connection parameters
-              checkmarx_url: https://cmxext.deltek.com
-              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-              team: "/CxServer/Security/Deltek/Replicon"
-              preset: "ASA Premium"
-
-              # Project configuration
-              project: Replicon-${{ github.event.repository.name }}
-              scanners: sast
-              incremental: true
-              break_build: false
-
-              # Scan parameters and thresholds
-              params: >-
-                --namespace=${{ github.repository_owner}}
-                --checkmarx.settings-override=true
-                --repo-name=${{ github.event.repository.name}}
-                --branch=${{ github.ref_name || github.head_ref}}
-                --cx-flow.filterSeverity
-                --cx-flow.thresholds.high=1
-                --cx-flow.thresholds.medium=1
-                --cx-flow.scan-resubmit=true
-                ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
-
-  checkmarx-scheduled-scan:
-        name: Checkmarx scheduled SAST Scan
-        runs-on: ubuntu-latest
-        concurrency:
-            group: checkmarx-scheduled-scan
-            cancel-in-progress: true
-        timeout-minutes: 360
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-
-        steps:
-          - name: Checkout Code
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ github.event.repository.default_branch }}
-
-          - name: Run Checkmarx SAST Scan
-            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-            with:
-              # Connection parameters
-              checkmarx_url: https://cmxext.deltek.com
-              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-              team: "/CxServer/Security/Deltek/Replicon"
-              preset: "ASA Premium"
-
-              # Project configuration
-              project: Replicon-${{ github.event.repository.name }}
-              scanners: sast
-              incremental: false
-              break_build: false
-
-              # Scan parameters and thresholds
-              params: >-
-                --namespace=${{ github.repository_owner}}
-                --checkmarx.settings-override=true
-                --repo-name=${{ github.event.repository.name}}
-                --branch=${{ github.event.repository.default_branch }}
-                --cx-flow.filterSeverity
-                --cx-flow.thresholds.high=1
-                --cx-flow.thresholds.medium=1
-                --cx-flow.scan-resubmit=true
- 

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,12 +1,11 @@
 on:
-  pull_request: {}
+  pull_request:
   push:
     branches:
     - main
     - master
   schedule:
-    # Run on the 28th of every month at 2 AM UTC (safe for all months)
-    - cron: '0 2 28 * *'
+    - cron: '0 13 * * 6'
   workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
@@ -14,71 +13,78 @@ jobs:
         name: Checkmarx SAST Scan
         runs-on: ubuntu-latest
         timeout-minutes: 90
-        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'  # Skip this job on scheduled runs
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+
         steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
-            - name: Run Checkmarx SAST Scan
-              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-              with:
-                # Connection parameters
-                checkmarx_url: https://cmxext.deltek.com
-                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-                team: "/CxServer/Security/Deltek/Replicon"
-                preset: "ASA Premium"
-                # Project configuration
-                project: Replicon-${{ github.event.repository.name }}
-                scanners: sast
-                # bug_tracker: GitHub
-                incremental: true
-                break_build: false
-                # Scan parameters and thresholds
-                params: >-
-                  --namespace=${{ github.repository_owner}}
-                  --checkmarx.settings-override=true
-                  --repo-name=${{ github.event.repository.name}}
-                  --branch=${{ github.ref_name || github.head_ref}}
-                  --cx-flow.filterSeverity
-                  --cx-flow.thresholds.high=1
-                  --cx-flow.thresholds.medium=1
-                  --cx-flow.scan-resubmit=true
-                  ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
-                  
+          - name: Checkout Code
+            uses: actions/checkout@v4
+
+          - name: Run Checkmarx SAST Scan
+            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+            with:
+              # Connection parameters
+              checkmarx_url: https://cmxext.deltek.com
+              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+              team: "/CxServer/Security/Deltek/Replicon"
+              preset: "ASA Premium"
+
+              # Project configuration
+              project: Replicon-${{ github.event.repository.name }}
+              scanners: sast
+              incremental: true
+              break_build: false
+
+              # Scan parameters and thresholds
+              params: >-
+                --namespace=${{ github.repository_owner}}
+                --checkmarx.settings-override=true
+                --repo-name=${{ github.event.repository.name}}
+                --branch=${{ github.ref_name || github.head_ref}}
+                --cx-flow.filterSeverity
+                --cx-flow.thresholds.high=1
+                --cx-flow.thresholds.medium=1
+                --cx-flow.scan-resubmit=true
+                ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
+
   checkmarx-scheduled-scan:
         name: Checkmarx scheduled SAST Scan
         runs-on: ubuntu-latest
         timeout-minutes: 360
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
         steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
-              with:
-                ref: ${{ github.event.repository.default_branch }}
-            - name: Run Checkmarx SAST Scan
-              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-              with:
-                # Connection parameters
-                checkmarx_url: https://cmxext.deltek.com
-                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-                team: "/CxServer/Security/Deltek/Replicon"
-                preset: "ASA Premium"
-                # Project configuration
-                project: Replicon-${{ github.event.repository.name }}
-                scanners: sast
-                # bug_tracker: GitHub
-                incremental: false
-                break_build: false
-                # Scan parameters and thresholds
-                params: >-
-                  --namespace=${{ github.repository_owner}}
-                  --checkmarx.settings-override=true
-                  --repo-name=${{ github.event.repository.name}}
-                  --branch=${{ github.event.repository.default_branch }}
-                  --cx-flow.filterSeverity
-                  --cx-flow.thresholds.high=1
-                  --cx-flow.thresholds.medium=1
-                  --cx-flow.scan-resubmit=true
+          - name: Checkout Code
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ github.event.repository.default_branch }}
+
+          - name: Run Checkmarx SAST Scan
+            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+            with:
+              # Connection parameters
+              checkmarx_url: https://cmxext.deltek.com
+              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+              team: "/CxServer/Security/Deltek/Replicon"
+              preset: "ASA Premium"
+
+              # Project configuration
+              project: Replicon-${{ github.event.repository.name }}
+              scanners: sast
+              incremental: false
+              break_build: false
+
+              # Scan parameters and thresholds
+              params: >-
+                --namespace=${{ github.repository_owner}}
+                --checkmarx.settings-override=true
+                --repo-name=${{ github.event.repository.name}}
+                --branch=${{ github.event.repository.default_branch }}
+                --cx-flow.filterSeverity
+                --cx-flow.thresholds.high=1
+                --cx-flow.thresholds.medium=1
+                --cx-flow.scan-resubmit=true
+ 


### PR DESCRIPTION
## Changes
This PR updates the Checkmarx SAST workflow to include:

- Scheduled monthly scans on the 28th of each month
- Separate job configurations for regular and scheduled scans
- Conditional execution based on event type
- Updated timeout settings for scheduled scans (360 minutes)

## Testing
- [ ] Workflow syntax is valid
- [ ] Scheduled scan runs successfully
- [ ] Regular PR scans still work as expected

## Related
- Ticket: RTI-40
